### PR TITLE
Add opts for specify location of node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function copyNodeModules(srcDir, dstDir, opts, callback)
     else
     {
         g_opts = opts || {};
-        g_opts.srcDir = srcDir;
+        g_opts.srcDir = g_opts.srcDir || srcDir;
         g_opts.dstDir = dstDir;
     }
 


### PR DESCRIPTION
I have a case when I need to specify the directory of `node_modules` because using https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/ .
I have separate client and server folder with separate `package.json` and I notice this package don't have an option to specifying the directory of src `node_modules`. 

This is what I want to achieve.
```
copyNodeModule(path.resolve(__dirname, '../server'), config.build.assetsRoot, {
      srcDir: __dirname,
      devDependencies: false
    }, (err, results) => {
```