### PR TITLE
Ignore "file:*" versioned dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,9 +93,11 @@ function addPkgDeps(baseDir, pkg, pkgs, callback)
     for (var pkgName in pkgContent.dependencies)
     {
         var version = pkgContent.dependencies[pkgName];
-        var depPkg = {name: pkgName, version: version};
-        addPkgDeps(g_opts.srcDir, depPkg, pkgs, callback);
-        addPkgDeps(pkgDir, depPkg, pkgs, callback);
+        if ( !version.startsWith('file:') {
+            var depPkg = {name: pkgName, version: version};
+            addPkgDeps(g_opts.srcDir, depPkg, pkgs, callback);
+            addPkgDeps(pkgDir, depPkg, pkgs, callback);
+        }
     }
 
 

--- a/index.js
+++ b/index.js
@@ -150,13 +150,20 @@ function copyNodeModules(srcDir, dstDir, opts, callback)
 
     // prepare root package list
     var rootPkgList = [];
-    for (var depPkgName in pkgContent.dependencies)
-        rootPkgList.push({name: depPkgName, version: pkgContent.dependencies[depPkgName]});
+    for (var depPkgName in pkgContent.dependencies) {
+        var version = pkgContent.dependencies[depPkgName]
+        if (!version.startsWith('file:')) {
+            rootPkgList.push({ name: depPkgName, version });
+        }
+    }
 
-    if (g_opts.devDependencies)
-    {
-        for (var devDepPkgName in pkgContent.devDependencies)
-            rootPkgList.push({name: devDepPkgName, version: pkgContent.dependencies[devDepPkgName]});
+    if (g_opts.devDependencies) {
+        for (var devDepPkgName in pkgContent.devDependencies) {
+            var version = pkgContent.dependencies[depPkgName]
+        }
+        if (!version.startsWith('file:')) {
+            rootPkgList.push({ name: devDepPkgName, version });
+        }
     }
 
     async.map(rootPkgList, findPkgDeps, function(err, results) {

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function addPkgDeps(baseDir, pkg, pkgs, callback)
     for (var pkgName in pkgContent.dependencies)
     {
         var version = pkgContent.dependencies[pkgName];
-        if ( !version.startsWith('file:') {
+        if ( !version.startsWith('file:') ) {
             var depPkg = {name: pkgName, version: version};
             addPkgDeps(g_opts.srcDir, depPkg, pkgs, callback);
             addPkgDeps(pkgDir, depPkg, pkgs, callback);


### PR DESCRIPTION
The plugin currently crashes when it encounters a local dependency, i.e., one with a version that reads something like `file:../my-other-package`.  

This patch makes the plugin ignore these.  The user is then responsible for fulfilling the dependency in some way.  I suspect requirements will vary.  In my case, I ended up copying the module into node_modules directly.